### PR TITLE
bump version of fbsdk to 9.0.1

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -9,20 +9,20 @@ PODS:
     - React-Core (= 0.63.3)
     - React-jsi (= 0.63.3)
     - ReactCommon/turbomodule/core (= 0.63.3)
-  - FBSDKCoreKit (9.0.0):
-    - FBSDKCoreKit/Basics (= 9.0.0)
-    - FBSDKCoreKit/Core (= 9.0.0)
-  - FBSDKCoreKit/Basics (9.0.0)
-  - FBSDKCoreKit/Core (9.0.0):
+  - FBSDKCoreKit (9.0.1):
+    - FBSDKCoreKit/Basics (= 9.0.1)
+    - FBSDKCoreKit/Core (= 9.0.1)
+  - FBSDKCoreKit/Basics (9.0.1)
+  - FBSDKCoreKit/Core (9.0.1):
     - FBSDKCoreKit/Basics
-  - FBSDKLoginKit (9.0.0):
-    - FBSDKLoginKit/Login (= 9.0.0)
-  - FBSDKLoginKit/Login (9.0.0):
-    - FBSDKCoreKit (~> 9.0.0)
-  - FBSDKShareKit (9.0.0):
-    - FBSDKShareKit/Share (= 9.0.0)
-  - FBSDKShareKit/Share (9.0.0):
-    - FBSDKCoreKit (~> 9.0.0)
+  - FBSDKLoginKit (9.0.1):
+    - FBSDKLoginKit/Login (= 9.0.1)
+  - FBSDKLoginKit/Login (9.0.1):
+    - FBSDKCoreKit (~> 9.0.1)
+  - FBSDKShareKit (9.0.1):
+    - FBSDKShareKit/Share (= 9.0.1)
+  - FBSDKShareKit/Share (9.0.1):
+    - FBSDKCoreKit (~> 9.0.1)
   - Folly (2020.01.13.00):
     - boost-for-react-native
     - DoubleConversion
@@ -205,13 +205,13 @@ PODS:
     - react-native-fbsdk/Login (= 3.0.0)
     - react-native-fbsdk/Share (= 3.0.0)
   - react-native-fbsdk/Core (3.0.0):
-    - FBSDKCoreKit (~> 9.0)
+    - FBSDKCoreKit (~> 9.0.1)
     - React
   - react-native-fbsdk/Login (3.0.0):
-    - FBSDKLoginKit (~> 9.0)
+    - FBSDKLoginKit (~> 9.0.1)
     - React
   - react-native-fbsdk/Share (3.0.0):
-    - FBSDKShareKit (~> 9.0)
+    - FBSDKShareKit (~> 9.0.1)
     - React
   - React-RCTActionSheet (0.63.3):
     - React-Core/RCTActionSheetHeaders (= 0.63.3)
@@ -374,9 +374,9 @@ SPEC CHECKSUMS:
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 878b59e31113e289e275165efbe4b54fa614d43d
   FBReactNativeSpec: 7da9338acfb98d4ef9e5536805a0704572d33c2f
-  FBSDKCoreKit: ac6cc500b8e104bb9a4dd20b1527b5d199123c2e
-  FBSDKLoginKit: e9b6542fdee322333502ab497f628b011dce7d78
-  FBSDKShareKit: e9a5d805d0831489a09dd14fa6fc8ba20d6355f3
+  FBSDKCoreKit: fada1a6a0076724678993ff05a633848765ff18c
+  FBSDKLoginKit: d5ffe6d808897019ccf16feb6f0a7ab260bc5cd6
+  FBSDKShareKit: 6a85acb92eaf43a0b6dfa2ba6106eb74c7f10d30
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   RCTRequired: 48884c74035a0b5b76dbb7a998bd93bcfc5f2047
@@ -389,7 +389,7 @@ SPEC CHECKSUMS:
   React-jsi: df07aa95b39c5be3e41199921509bfa929ed2b9d
   React-jsiexecutor: b56c03e61c0dd5f5801255f2160a815f4a53d451
   React-jsinspector: 8e68ffbfe23880d3ee9bafa8be2777f60b25cbe2
-  react-native-fbsdk: 63d0974790749fab91727b21799af4acd37cf04f
+  react-native-fbsdk: e05fad83e6fa5180ae5d1e447dfa32c8430ca830
   React-RCTActionSheet: 53ea72699698b0b47a6421cb1c8b4ab215a774aa
   React-RCTAnimation: 1befece0b5183c22ae01b966f5583f42e69a83c2
   React-RCTBlob: 0b284339cbe4b15705a05e2313a51c6d8b51fa40

--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -14,17 +14,17 @@ Pod::Spec.new do |s|
   s.dependency      'React'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit', '~> 9.0'
+    ss.dependency     'FBSDKCoreKit', '~> 9.0.1'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit', '~> 9.0'
+    ss.dependency     'FBSDKLoginKit', '~> 9.0.1'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit', '~> 9.0'
+    ss.dependency     'FBSDKShareKit', '~> 9.0.1'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end


### PR DESCRIPTION
This version of the FBSDK fixes a crash on startup on iOS